### PR TITLE
Fix error during switch-to-packages/projects when using Microsoft.Web.WebJobs.Publish in an Sdk project

### DIFF
--- a/src/Dnt.Commands/ProjectExtensions.cs
+++ b/src/Dnt.Commands/ProjectExtensions.cs
@@ -69,7 +69,11 @@ namespace Dnt.Commands
             var legacyToolsPath = GetToolsPath();
             var sdkToolsPath = GetSdkBasePath(projectPath);
 
+            var legacyProperties = GetLegacyGlobalProperties(projectPath, legacyToolsPath);
             var globalProperties = GetSdkGlobalProperties(projectPath, sdkToolsPath);
+
+            globalProperties.Add("MSBuildExtensionsPath32", legacyProperties["MSBuildExtensionsPath32"]);
+
             Environment.SetEnvironmentVariable(
                 "MSBuildExtensionsPath",
                 globalProperties["MSBuildExtensionsPath"]);


### PR DESCRIPTION
Add "MSBuildExtensionsPath32" to globalProperties even within an Sdk project so that Microsoft.WebApplication.targets can be found within console apps using Microsoft.Web.WebJobs.Publish.

This fixes this error:

```
The project 'C:\Dev\SystemCleanUp\SystemCleanUp.csproj' could not be loaded: 
The imported project "C:\Program Files\dotnet\sdk\2.2.202\Microsoft\VisualStudio\v16.0\WebApplications\Microsoft.WebApplication.targets" was not found. 
Confirm that the path in the <Import> declaration is correct, and that the file exists on disk.  
C:\Users\thecontrarycat\.nuget\packages\microsoft.web.webjobs.publish\2.0.0\build\webjobs.console.targets
```