### PR TITLE
Improve Cross-platform Compatibility

### DIFF
--- a/src/Dnt.Commands/CommandBase.cs
+++ b/src/Dnt.Commands/CommandBase.cs
@@ -17,7 +17,7 @@ namespace Dnt.Commands
 
         public abstract Task<object> RunAsync(CommandLineProcessor processor, IConsoleHost host);
 
-        protected async Task ExecuteCommandAsync(string command, IConsoleHost host)
+        protected async Task ExecuteCommandAsync(string command, string arguments, IConsoleHost host)
         {
             if (Simulate)
             {
@@ -25,7 +25,7 @@ namespace Dnt.Commands
             }
             else
             {
-                await ProcessUtilities.ExecuteAsync(command, Verbose);
+                await ProcessUtilities.ExecuteAsync(command, arguments, Verbose);
             }
         }
     }

--- a/src/Dnt.Commands/Dnt.Commands.csproj
+++ b/src/Dnt.Commands/Dnt.Commands.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp2.1;netcoreapp2.2</TargetFrameworks>
     <RootNamespace>Dnt.Commands</RootNamespace>
@@ -7,7 +7,7 @@
     <Authors>Rico Suter</Authors>
     <Company>Rico Suter</Company>
     <PackageId>DNT.Commands</PackageId>
-    <Version>1.2.5</Version>
+    <Version>1.3.0</Version>
     <Description>Command line tools to manage .NET Core, Standard and SDK-style projects and solutions.</Description>
     <PackageProjectUrl>https://github.com/RSuter/DNT</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/RSuter/DNT/blob/master/LICENSE.md</PackageLicenseUrl>
@@ -18,13 +18,14 @@
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="NuGet.Client" Version="4.2.0" />
     <PackageReference Include="NuGet.Protocol.Core.v3" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.1'">
-    <PackageReference Include="Microsoft.Build" Version="16.0.461" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.0.461" />
+    <PackageReference Include="Microsoft.Build" Version="16.0.461" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.0.461" ExcludeAssets="runtime" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="Microsoft.Build" Version="15.9.20" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" />
+    <PackageReference Include="Microsoft.Build" Version="15.9.20" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" ExcludeAssets="runtime" />
   </ItemGroup>
 </Project>

--- a/src/Dnt.Commands/Infrastructure/ProcessUtilities.cs
+++ b/src/Dnt.Commands/Infrastructure/ProcessUtilities.cs
@@ -6,15 +6,15 @@ namespace Dnt.Commands.Infrastructure
 {
     public static class ProcessUtilities
     {
-        public static async Task ExecuteAsync(string command, bool verbose)
+        public static async Task ExecuteAsync(string command, string arguments, bool verbose)
         {
             var taskSource = new TaskCompletionSource<object>();
             var process = new Process
             {
                 StartInfo = new ProcessStartInfo
                 {
-                    FileName = "cmd.exe",
-                    Arguments = "/c " + command,
+                    FileName = command,
+                    Arguments = arguments,
                     UseShellExecute = false,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,

--- a/src/Dnt.Commands/Packages/InstallPackagesCommand.cs
+++ b/src/Dnt.Commands/Packages/InstallPackagesCommand.cs
@@ -39,7 +39,7 @@ namespace Dnt.Commands.Packages
                 {
                     try
                     {
-                        await ExecuteCommandAsync("dotnet add \"" + projectPath + "\" package " + Package + version, host);
+                        await ExecuteCommandAsync("dotnet", "add \"" + projectPath + "\" package " + Package + version, host);
                     }
                     catch (Exception e)
                     {

--- a/src/Dnt.Commands/Packages/SwitchPackagesToProjectsCommand.cs
+++ b/src/Dnt.Commands/Packages/SwitchPackagesToProjectsCommand.cs
@@ -47,7 +47,7 @@ namespace Dnt.Commands.Packages
             if (projects.Any())
             {
                 await ExecuteCommandAsync(
-                    "dotnet sln \"" + configuration.ActualSolution + "\" add " + string.Join(" ", projects), host);
+                    "dotnet", "sln \"" + configuration.ActualSolution + "\" add " + string.Join(" ", projects), host);
             }
         }
 

--- a/src/Dnt.Commands/Packages/SwitchProjectsToPackagesCommand.cs
+++ b/src/Dnt.Commands/Packages/SwitchProjectsToPackagesCommand.cs
@@ -92,7 +92,7 @@ namespace Dnt.Commands.Packages
 
             if (projects.Any())
             {
-                await ExecuteCommandAsync("dotnet sln \"" + configuration.ActualSolution + "\" remove " + string.Join(" ", projects), host);
+                await ExecuteCommandAsync("dotnet", "sln \"" + configuration.ActualSolution + "\" remove " + string.Join(" ", projects), host);
             }
         }
 

--- a/src/Dnt.Commands/Packages/UpdatePackagesCommand.cs
+++ b/src/Dnt.Commands/Packages/UpdatePackagesCommand.cs
@@ -70,7 +70,7 @@ namespace Dnt.Commands.Packages
 
                     foreach (var package in packages)
                     {
-                        await ExecuteCommandAsync("dotnet add \"" + projectPath + "\" package \"" + package + "\"" + (version != null ? " -v " + version : ""), host);
+                        await ExecuteCommandAsync("dotnet", "add \"" + projectPath + "\" package \"" + package + "\"" + (version != null ? " -v " + version : ""), host);
                     }
                 }               
             }

--- a/src/Dnt.Commands/ProjectExtensions.cs
+++ b/src/Dnt.Commands/ProjectExtensions.cs
@@ -5,6 +5,8 @@ using System.IO;
 using System.Linq;
 using System.Xml;
 using Microsoft.Build.Evaluation;
+using Microsoft.Build.Exceptions;
+using Microsoft.Build.Locator;
 using Microsoft.Build.Utilities;
 
 namespace Dnt.Commands
@@ -33,192 +35,39 @@ namespace Dnt.Commands
         {
             // Based on https://daveaglick.com/posts/running-a-design-time-build-with-msbuild-apis
 
+            var globalProperties = GetGlobalProperties(projectPath);
+
+            var isSdkStyle = false;
+
             using (var reader = XmlReader.Create(projectPath))
             {
                 if (reader.MoveToContent() == XmlNodeType.Element && reader.HasAttributes)
                 {
-                    var isSdkStyle = reader.MoveToAttribute("Sdk");
-                    if (isSdkStyle)
-                    {
-                        return GetSdkProject(projectPath);
-                    }
-                    else
-                    {
-                        return GetLegacyProject(projectPath);
-                    }
+                    isSdkStyle = reader.MoveToAttribute("Sdk");
                 }
             }
 
-            throw new InvalidOperationException("Not a project: " + projectPath);
-        }
-
-        private static ProjectInformation GetLegacyProject(string projectPath)
-        {
-            var legacyToolsPath = GetToolsPath();
-
-            var globalProperties = GetLegacyGlobalProperties(projectPath, legacyToolsPath);
-            var projectCollection = new ProjectCollection(globalProperties);
-            projectCollection.AddToolset(new Toolset(ToolLocationHelper.CurrentToolsVersion, legacyToolsPath, projectCollection, string.Empty));
-
-            var project = projectCollection.LoadProject(projectPath);
-            return new ProjectInformation(projectCollection, project, true);
-        }
-
-        private static ProjectInformation GetSdkProject(string projectPath)
-        {
-            var legacyToolsPath = GetToolsPath();
-            var sdkToolsPath = GetSdkBasePath(projectPath);
-
-            var legacyProperties = GetLegacyGlobalProperties(projectPath, legacyToolsPath);
-            var globalProperties = GetSdkGlobalProperties(projectPath, sdkToolsPath);
-
-            globalProperties.Add("MSBuildExtensionsPath32", legacyProperties["MSBuildExtensionsPath32"]);
-
-            Environment.SetEnvironmentVariable(
-                "MSBuildExtensionsPath",
-                globalProperties["MSBuildExtensionsPath"]);
-            Environment.SetEnvironmentVariable(
-                "MSBuildSDKsPath",
-                globalProperties["MSBuildSDKsPath"]);
-
-            var projectCollection = new ProjectCollection(globalProperties);
-            projectCollection.AddToolset(new Toolset(ToolLocationHelper.CurrentToolsVersion, legacyToolsPath, projectCollection, string.Empty));
-            projectCollection.AddToolset(new Toolset(ToolLocationHelper.CurrentToolsVersion, sdkToolsPath, projectCollection, string.Empty));
-
-            var project = projectCollection.LoadProject(projectPath);
-            return new ProjectInformation(projectCollection, project, false);
-        }
-
-        public static string GetToolsPath()
-        {
-            var toolsPath = ToolLocationHelper.GetPathToBuildToolsFile("msbuild.exe", ToolLocationHelper.CurrentToolsVersion);
-
-            if (string.IsNullOrEmpty(toolsPath))
-            {
-                toolsPath = GetToolsPaths().FirstOrDefault();
-            }
-
-            if (string.IsNullOrEmpty(toolsPath))
-            {
-                throw new Exception("Could not locate the tools (MSBuild) path.");
-            }
-
-            return Path.GetDirectoryName(toolsPath);
-        }
-
-        private static string[] GetToolsPaths()
-        {
-            var programFilesX86 = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
-
-            return new[]
-            {
-                Path.Combine(programFilesX86, @"Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\MSBuild.exe"),
-                Path.Combine(programFilesX86, @"Microsoft Visual Studio\2019\Professional\MSBuild\Current\Bin\MSBuild.exe"),
-                Path.Combine(programFilesX86, @"Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\MSBuild.exe"),
-
-                Path.Combine(programFilesX86, @"Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe"),
-                Path.Combine(programFilesX86, @"Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin\MSBuild.exe"),
-                Path.Combine(programFilesX86, @"Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe"),
-
-                Path.Combine(programFilesX86, @"MSBuild\14.0\Bin\MSBuild.exe"),
-                Path.Combine(programFilesX86, @"MSBuild\12.0\Bin\MSBuild.exe")
-            }.Where(File.Exists).ToArray();
-        }
-
-        private static Dictionary<string, string> GetLegacyGlobalProperties(string projectPath, string toolsPath)
-        {
-            var solutionDir = Path.GetDirectoryName(projectPath);
-            var extensionsPath = Path.GetFullPath(Path.Combine(toolsPath, @"..\..\"));
-            var sdksPath = Path.Combine(extensionsPath, "Sdks");
-            var roslynTargetsPath = Path.Combine(toolsPath, "Roslyn");
-
-            return new Dictionary<string, string>
-            {
-                { "SolutionDir", solutionDir },
-                { "MSBuildExtensionsPath", extensionsPath },
-                { "MSBuildExtensionsPath32", extensionsPath },
-                { "MSBuildSDKsPath", sdksPath },
-                { "RoslynTargetsPath", roslynTargetsPath }
-            };
-        }
-
-        private static Dictionary<string, string> GetSdkGlobalProperties(string projectPath, string toolsPath)
-        {
-            var solutionDir = Path.GetDirectoryName(projectPath);
-            var extensionsPath = toolsPath;
-            var sdksPath = Path.Combine(toolsPath, "Sdks");
-            var roslynTargetsPath = Path.Combine(toolsPath, "Roslyn");
-
-            return new Dictionary<string, string>
-            {
-                { "SolutionDir", solutionDir },
-                { "MSBuildExtensionsPath", extensionsPath },
-                { "MSBuildSDKsPath", sdksPath },
-                { "RoslynTargetsPath", roslynTargetsPath }
-            };
-        }
-
-        private static string GetSdkBasePath(string projectPath)
-        {
-            // Ensure that we set the DOTNET_CLI_UI_LANGUAGE environment variable to "en-US" before
-            // running 'dotnet --info'. Otherwise, we may get localized results.
-            var originalCliLanguage = Environment.GetEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE");
-
-            Environment.SetEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE", "en-US");
             try
             {
-                // Create the process info
-                var startInfo = new ProcessStartInfo("dotnet", "--info")
-                {
-                    // global.json may change the version, so need to set working directory
-                    WorkingDirectory = Path.GetDirectoryName(projectPath),
-                    CreateNoWindow = true,
-                    UseShellExecute = false,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true
-                };
+                var projectCollection = new ProjectCollection(globalProperties);
+                var project = projectCollection.LoadProject(projectPath);
 
-                // Execute the process
-                using (var process = Process.Start(startInfo))
-                {
-                    var lines = new List<string>();
-                    process.OutputDataReceived += (_, e) =>
-                    {
-                        if (!string.IsNullOrWhiteSpace(e.Data))
-                        {
-                            lines.Add(e.Data);
-                        }
-                    };
-
-                    process.BeginOutputReadLine();
-                    process.WaitForExit();
-                    return ParseSdkBasePath(lines);
-                }
+                return new ProjectInformation(projectCollection, project, !isSdkStyle);
             }
-            finally
+            catch (InvalidProjectFileException projectFileException)
             {
-                Environment.SetEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE", originalCliLanguage);
+                throw new InvalidOperationException("Not a project: " + projectPath, projectFileException);
             }
         }
 
-        private static string ParseSdkBasePath(List<string> lines)
+        private static Dictionary<string, string> GetGlobalProperties(string projectPath)
         {
-            if (lines == null || lines.Count == 0)
-            {
-                throw new Exception("Could not get results from `dotnet --info` call");
-            }
+            var solutionDir = Path.GetDirectoryName(projectPath);
 
-            foreach (string line in lines)
+            return new Dictionary<string, string>
             {
-                var colonIndex = line.IndexOf(':');
-                if (colonIndex >= 0 &&
-                    line.Substring(0, colonIndex).Trim().Equals("Base Path", StringComparison.OrdinalIgnoreCase))
-                {
-                    return line.Substring(colonIndex + 1).Trim();
-                }
-            }
-
-            throw new Exception("Could not locate base path in `dotnet --info` results");
+                { "SolutionDir", solutionDir }
+            };
         }
     }
 }

--- a/src/Dnt.Commands/Solutions/CreateSolutionCommand.cs
+++ b/src/Dnt.Commands/Solutions/CreateSolutionCommand.cs
@@ -47,25 +47,25 @@ namespace Dnt.Commands.Solutions
         {
             ConsoleUtilities.Write("Install templates? [yes|no]");
             if (Console.ReadLine() == "yes")
-                await ExecuteCommandAsync("dotnet new --install Microsoft.AspNetCore.SpaTemplates::*", host);
+                await ExecuteCommandAsync("dotnet", "new --install Microsoft.AspNetCore.SpaTemplates::*", host);
         }
 
         private async Task CreateApplicationProjectAsync(string appDirectory, IConsoleHost host)
         {
             Directory.SetCurrentDirectory(appDirectory);
 
-            await ExecuteCommandAsync("dotnet new " + Type, host);
-            await ExecuteCommandAsync("dotnet restore", host);
+            await ExecuteCommandAsync("dotnet", "new " + Type, host);
+            await ExecuteCommandAsync("dotnet", "restore", host);
 
             if (File.Exists("package.json"))
-                await ExecuteCommandAsync("npm i", host);
+                await ExecuteCommandAsync("npm", "i", host);
         }
 
         private async Task CreateClientsProjectAsync(string clientsDirectory, IConsoleHost host)
         {
             Directory.SetCurrentDirectory(clientsDirectory);
-            await ExecuteCommandAsync("dotnet new classlib", host);
-            await ExecuteCommandAsync("dotnet restore", host);
+            await ExecuteCommandAsync("dotnet", "new classlib", host);
+            await ExecuteCommandAsync("dotnet", "restore", host);
         }
     }
 }

--- a/src/Dnt/Dnt.csproj
+++ b/src/Dnt/Dnt.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp2.1;netcoreapp2.2</TargetFrameworks>
@@ -10,7 +10,7 @@
     <Authors>Rico Suter</Authors>
     <Company>Rico Suter</Company>
     <Product>DotNetTools (DNT)</Product>
-    <Version>1.2.5</Version>
+    <Version>1.3.0</Version>
     <PackageId>DNT</PackageId>
     <DebugType>embedded</DebugType>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
@@ -29,13 +29,14 @@
     <PackageReference Include="NConsole" Version="3.12.6605.26941" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.1'">
-    <PackageReference Include="Microsoft.Build" Version="16.0.461" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.0.461" />
+    <PackageReference Include="Microsoft.Build" Version="16.0.461" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.0.461" ExcludeAssets="runtime" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="Microsoft.Build" Version="15.9.20" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" />
+    <PackageReference Include="Microsoft.Build" Version="15.9.20" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" ExcludeAssets="runtime" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
For #52 

After looking at things, it didn't seem reasonable to maintain two separate methods for detecting MSBuild / Visual Studio so I made it use Microsoft.Build.Locator for everything and it seems to work well. It takes care of setting all the necessary global properties and environment variables automatically. The only possible catch is that it won't find MSBuild older than 15 but since DNT already requires VS2019, I figured that was a reasonable compromise.

Because the detection method changed so much, I bumped the minor version to 1.3.0. Of course the final version change is up to you.

I haven't been able to test on Windows so please try it out and let me know how it works for you.