### PR TITLE
Fix when switch.json is in folder that is not same as the solution file folder

### DIFF
--- a/src/Dnt.Commands/Packages/SwitchProjectsToPackagesCommand.cs
+++ b/src/Dnt.Commands/Packages/SwitchProjectsToPackagesCommand.cs
@@ -82,7 +82,7 @@ namespace Dnt.Commands.Packages
                 foreach (var path in mapping.Value)
                 {
                     var project = solution.ProjectsInOrder.FirstOrDefault
-                        (p => configuration.GetActualPath(p.RelativePath) == configuration.GetActualPath(path));
+                        (p => PathUtilities.ToAbsolutePath(p.RelativePath, Path.GetDirectoryName(configuration.ActualSolution)) == configuration.GetActualPath(path));
                     if (project != null)
                     {
                         projects.Add("\"" + configuration.GetActualPath(path) + "\"");


### PR DESCRIPTION
Fixes the wrong path calculation when switch.json is in the folder inside the solution folder(The packages to projects works, but projects to packages won't).