### PR TITLE
Added details from inner exception to help with troubleshooting

### DIFF
--- a/src/Dnt.Commands/Packages/SwitchPackagesToProjectsCommand.cs
+++ b/src/Dnt.Commands/Packages/SwitchPackagesToProjectsCommand.cs
@@ -79,8 +79,7 @@ namespace Dnt.Commands.Packages
                     }
                     catch (Exception e)
                     {
-                        host.WriteError("The project '" + solutionProject.AbsolutePath + "' could not be loaded: " +
-                                        e.Message + "\n" + (e.InnerException == null ? "" : "\nDetails: " + e.InnerException.Message + "\n"));
+                        host.WriteError($"The project '{solutionProject.AbsolutePath}' could not be loaded: {e}\n");
                     }
                 }
             }

--- a/src/Dnt.Commands/Packages/SwitchPackagesToProjectsCommand.cs
+++ b/src/Dnt.Commands/Packages/SwitchPackagesToProjectsCommand.cs
@@ -80,7 +80,7 @@ namespace Dnt.Commands.Packages
                     catch (Exception e)
                     {
                         host.WriteError("The project '" + solutionProject.AbsolutePath + "' could not be loaded: " +
-                                        e.Message + "\n");
+                                        e.Message + "\n" + (e.InnerException == null ? "" : "\nDetails: " + e.InnerException.Message + "\n"));
                     }
                 }
             }

--- a/src/Dnt.Commands/Packages/SwitchProjectsToPackagesCommand.cs
+++ b/src/Dnt.Commands/Packages/SwitchProjectsToPackagesCommand.cs
@@ -67,7 +67,7 @@ namespace Dnt.Commands.Packages
                     catch (Exception e)
                     {
                         host.WriteError("The project '" + solutionProject.AbsolutePath + "' could not be loaded: " +
-                                        e.Message + "\n");
+                                        e.Message + "\n" + (e.InnerException == null ? "" : "\nDetails: " + e.InnerException.Message + "\n"));
                     }
                 }
             }

--- a/src/Dnt.Commands/Packages/SwitchProjectsToPackagesCommand.cs
+++ b/src/Dnt.Commands/Packages/SwitchProjectsToPackagesCommand.cs
@@ -66,8 +66,7 @@ namespace Dnt.Commands.Packages
                     }
                     catch (Exception e)
                     {
-                        host.WriteError("The project '" + solutionProject.AbsolutePath + "' could not be loaded: " +
-                                        e.Message + "\n" + (e.InnerException == null ? "" : "\nDetails: " + e.InnerException.Message + "\n"));
+                        host.WriteError($"The project '{solutionProject.AbsolutePath}' could not be loaded: {e}\n");
                     }
                 }
             }

--- a/src/Dnt.Commands/Projects/SwitchAssembliesToProjectsCommand.cs
+++ b/src/Dnt.Commands/Projects/SwitchAssembliesToProjectsCommand.cs
@@ -58,9 +58,7 @@ namespace Dnt.Commands.Projects
                 }
                 catch (Exception e)
                 {
-                    host.WriteError("The project '" + project.FullPath + "' could not be loaded: " +
-                                    e.Message + "\n" + (e.InnerException == null ? "" : "\nDetails: " + e.InnerException.Message + "\n"));
-
+                    host.WriteError($"The project '{project.FullPath}' could not be loaded: {e}\n");
                 }
             }
 

--- a/src/Dnt.Commands/Projects/SwitchAssembliesToProjectsCommand.cs
+++ b/src/Dnt.Commands/Projects/SwitchAssembliesToProjectsCommand.cs
@@ -58,7 +58,9 @@ namespace Dnt.Commands.Projects
                 }
                 catch (Exception e)
                 {
-                    host.WriteError("The project '" + project.FullPath + "' could not be loaded: " + e.Message + "\n");
+                    host.WriteError("The project '" + project.FullPath + "' could not be loaded: " +
+                                    e.Message + "\n" + (e.InnerException == null ? "" : "\nDetails: " + e.InnerException.Message + "\n"));
+
                 }
             }
 


### PR DESCRIPTION
My switcher command was failing and all it displayed was "Project could not be loaded" with the details of "Not a project" but no details on exactly what the problem was. After debugging, I discovered I had an import in my project that was causing the project to not load. By adding the details from the inner exception (if it's not null), provides the necessary details to resolve the problem.