### PR TITLE
Determine SolutionDir property from solution path, if possible.

### DIFF
--- a/src/Dnt.Commands/Packages/ListUsedPackagesCommand.cs
+++ b/src/Dnt.Commands/Packages/ListUsedPackagesCommand.cs
@@ -64,11 +64,13 @@ namespace Dnt.Commands.Packages
         {
             host.WriteMessage($"Loading projects ");
 
+            var globalProperties = TryGetGlobalProperties();
+
             foreach (var projectPath in GetProjectPaths())
             {
                 try
                 {
-                    using (var projectInformation = ProjectExtensions.LoadProject(projectPath))
+                    using (var projectInformation = ProjectExtensions.LoadProject(projectPath, globalProperties))
                     {
                         foreach (var item in projectInformation.Project.Items.Where(i => i.ItemType == "PackageReference").ToList())
                         {

--- a/src/Dnt.Commands/Packages/SwitchPackagesToProjectsCommand.cs
+++ b/src/Dnt.Commands/Packages/SwitchPackagesToProjectsCommand.cs
@@ -58,13 +58,15 @@ namespace Dnt.Commands.Packages
         private static void SwitchToProjects(ReferenceSwitcherConfiguration configuration, IConsoleHost host)
         {
             var solution = SolutionFile.Parse(configuration.ActualSolution);
+            var globalProperties = ProjectExtensions.GetGlobalProperties(Path.GetFullPath(configuration.ActualSolution));
+
             foreach (var solutionProject in solution.ProjectsInOrder)
             {
                 if (solutionProject.ProjectType != SolutionProjectType.SolutionFolder && solutionProject.ProjectType != SolutionProjectType.Unknown)
                 {
                     try
                     {
-                        using (var projectInformation = ProjectExtensions.LoadProject(solutionProject.AbsolutePath))
+                        using (var projectInformation = ProjectExtensions.LoadProject(solutionProject.AbsolutePath, globalProperties))
                         {
                             foreach (var mapping in configuration.Mappings)
                             {

--- a/src/Dnt.Commands/Packages/SwitchProjectsToPackagesCommand.cs
+++ b/src/Dnt.Commands/Packages/SwitchProjectsToPackagesCommand.cs
@@ -37,6 +37,7 @@ namespace Dnt.Commands.Packages
         private static void SwitchToPackages(IConsoleHost host, ReferenceSwitcherConfiguration configuration)
         {
             var solution = SolutionFile.Parse(configuration.ActualSolution);
+            var globalProperties = ProjectExtensions.GetGlobalProperties(Path.GetFullPath(configuration.ActualSolution));
             var mappedProjectFilePaths = configuration.Mappings.Values
                      .SelectMany(x => x)
                      .Select(p => Path.GetFileName(p))
@@ -49,7 +50,7 @@ namespace Dnt.Commands.Packages
                 {
                     try
                     {
-                        using (var projectInformation = ProjectExtensions.LoadProject(solutionProject.AbsolutePath))
+                        using (var projectInformation = ProjectExtensions.LoadProject(solutionProject.AbsolutePath, globalProperties))
                         {
                             foreach (var mapping in configuration.Mappings)
                             {

--- a/src/Dnt.Commands/ProjectCommandBase.cs
+++ b/src/Dnt.Commands/ProjectCommandBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.Build.Construction;
@@ -26,6 +27,21 @@ namespace Dnt.Commands
 
             var path = Directory.Exists(Path) ? Path : Directory.GetCurrentDirectory();
             return Directory.GetFiles(path, "*.csproj", SearchOption.AllDirectories);
+        }
+
+        protected IDictionary<string, string> TryGetGlobalProperties()
+        {
+            if (PathIsSolutionFile())
+            {
+                return ProjectExtensions.GetGlobalProperties(System.IO.Path.GetFullPath(Path));
+            }
+
+            return null;
+        }
+
+        private bool PathIsSolutionFile()
+        {
+            return File.Exists(Path) && Path.EndsWith(".sln");
         }
     }
 }

--- a/src/Dnt.Commands/ProjectExtensions.cs
+++ b/src/Dnt.Commands/ProjectExtensions.cs
@@ -31,11 +31,14 @@ namespace Dnt.Commands
             return (projectAbsolutePath.EndsWith(".csproj") || projectAbsolutePath.EndsWith(".vbproj"));
         }
 
-        public static ProjectInformation LoadProject(string projectPath)
+        public static ProjectInformation LoadProject(string projectPath, IDictionary<string, string> globalProperties = null)
         {
             // Based on https://daveaglick.com/posts/running-a-design-time-build-with-msbuild-apis
 
-            var globalProperties = GetGlobalProperties(projectPath);
+            if (globalProperties == null)
+            {
+                globalProperties = GetGlobalProperties(projectPath);
+            }
 
             var isSdkStyle = false;
 
@@ -60,9 +63,10 @@ namespace Dnt.Commands
             }
         }
 
-        private static Dictionary<string, string> GetGlobalProperties(string projectPath)
+        public static Dictionary<string, string> GetGlobalProperties(string projectOrSolutionPath)
         {
-            var solutionDir = Path.GetDirectoryName(projectPath);
+            // SolutionDir always ends with directory separator character
+            var solutionDir = $"{Path.GetDirectoryName(projectOrSolutionPath)}{Path.DirectorySeparatorChar}";
 
             return new Dictionary<string, string>
             {

--- a/src/Dnt.Commands/Projects/AddTargetFrameworkCommand.cs
+++ b/src/Dnt.Commands/Projects/AddTargetFrameworkCommand.cs
@@ -20,11 +20,13 @@ namespace Dnt.Commands.Projects
                 return Task.FromResult<object>(null);
             }
 
+            var globalProperties = TryGetGlobalProperties();
+
             foreach (var projectPath in GetProjectPaths())
             {
                 try
                 {
-                    using (var projectInformation = ProjectExtensions.LoadProject(projectPath))
+                    using (var projectInformation = ProjectExtensions.LoadProject(projectPath, globalProperties))
                     {
                         var project = projectInformation.Project;
 

--- a/src/Dnt.Commands/Projects/BumpVersionsCommand.cs
+++ b/src/Dnt.Commands/Projects/BumpVersionsCommand.cs
@@ -19,11 +19,13 @@ namespace Dnt.Commands.Projects
 
         public override Task<object> RunAsync(CommandLineProcessor processor, IConsoleHost host)
         {
+            var globalProperties = TryGetGlobalProperties();
+
             foreach (var projectPath in GetProjectPaths())
             {
                 try
                 {
-                    using (var projectInformation = ProjectExtensions.LoadProject(projectPath))
+                    using (var projectInformation = ProjectExtensions.LoadProject(projectPath, globalProperties))
                     {
                         if (projectInformation.Project.GeneratesPackage() || projectInformation.Project.HasVersion())
                         {

--- a/src/Dnt.Commands/Projects/ChangeVersionsCommand.cs
+++ b/src/Dnt.Commands/Projects/ChangeVersionsCommand.cs
@@ -23,7 +23,7 @@ namespace Dnt.Commands.Projects
 
         public override Task<object> RunAsync(CommandLineProcessor processor, IConsoleHost host)
         {
-           
+
             if (Version.IndexOf(".") < 0)
             {
                 host.WriteError("Version number must include at least two parts \n");
@@ -32,11 +32,13 @@ namespace Dnt.Commands.Projects
 
             bool isReplaceOnly = !ACTION_FORCE.Equals(Action, StringComparison.InvariantCultureIgnoreCase);
 
+            var globalProperties = TryGetGlobalProperties();
+
             foreach (var projectPath in GetProjectPaths())
             {
                 try
                 {
-                    using (var projectInformation = ProjectExtensions.LoadProject(projectPath))
+                    using (var projectInformation = ProjectExtensions.LoadProject(projectPath, globalProperties))
                     {
                         bool projectHasVersion = projectInformation.Project.HasVersion();
                         bool projectGeneratesPackage = projectInformation.Project.GeneratesPackage();
@@ -60,7 +62,7 @@ namespace Dnt.Commands.Projects
                             {
                                 host.WriteMessage($"[ ] Skipping {System.IO.Path.GetFileName(projectPath)} is already set to {versions.Item1}\n");
                             }
-                            
+
                         }
                         else
                         {

--- a/src/Dnt.Commands/Projects/EnableCommand.cs
+++ b/src/Dnt.Commands/Projects/EnableCommand.cs
@@ -14,12 +14,13 @@ namespace Dnt.Commands.Projects
 
         public override Task<object> RunAsync(CommandLineProcessor processor, IConsoleHost host)
         {
+            var globalProperties = TryGetGlobalProperties();
 
             foreach (var projectPath in GetProjectPaths())
             {
                 try
                 {
-                    using (var projectInformation = ProjectExtensions.LoadProject(projectPath))
+                    using (var projectInformation = ProjectExtensions.LoadProject(projectPath, globalProperties))
                     {
                         var project = projectInformation.Project;
 

--- a/src/Dnt.Commands/Projects/NoWarnCommand.cs
+++ b/src/Dnt.Commands/Projects/NoWarnCommand.cs
@@ -13,12 +13,13 @@ namespace Dnt.Commands.Projects
 
         public override Task<object> RunAsync(CommandLineProcessor processor, IConsoleHost host)
         {
+            var globalProperties = TryGetGlobalProperties();
 
             foreach (var projectPath in GetProjectPaths())
             {
                 try
                 {
-                    using (var projectInformation = ProjectExtensions.LoadProject(projectPath))
+                    using (var projectInformation = ProjectExtensions.LoadProject(projectPath, globalProperties))
                     {
                         var project = projectInformation.Project;
 

--- a/src/Dnt.Commands/Projects/SwitchAssembliesToProjectsCommand.cs
+++ b/src/Dnt.Commands/Projects/SwitchAssembliesToProjectsCommand.cs
@@ -13,14 +13,16 @@ namespace Dnt.Commands.Projects
     {
         public override Task<object> RunAsync(CommandLineProcessor processor, IConsoleHost host)
         {
-            var projects = GetProjectPaths().Select(p => ProjectExtensions.LoadProject(p)).ToList();
+            var globalProperties = TryGetGlobalProperties();
+
+            var projects = GetProjectPaths().Select(p => ProjectExtensions.LoadProject(p, globalProperties)).ToList();
             var projectNames = projects.Select(p => System.IO.Path.GetFileNameWithoutExtension(p.Project.FullPath));
 
             foreach (var project in projects.Select(p => p.Project))
             {
                 try
                 {
-                    using (var projectInformation = ProjectExtensions.LoadProject(project.FullPath))
+                    using (var projectInformation = ProjectExtensions.LoadProject(project.FullPath, globalProperties))
                     {
                         var newProjectsToReference = new List<Project>();
                         var assemblyReferencesToRemove = new List<ProjectItem>();


### PR DESCRIPTION
* Determines `SolutionDir` property from solution path, if possible.
* Ensures `SolutionDir` ends with directory separator char (`\` on Windows).

Fixes #85.