### PR TITLE
Adding a removeProjects flag to control removing projects from the solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,10 @@ dnt switch-to-projects switch-config.json
 
 Now all NJsonSchema package references in the NSwag solution are replaced by local project references and the NJsonSchema projects are added to the solution.
 
+**Optional `switcher.json` Flags:**
+
+- removeProjects: (Default: true) Removes mapped projects from the solution and ignores mapped projects when using switch-to-packages.
+
 ### switch-to-packages
 
 After implementing and testing, switch back to NuGet references and update to the latest version: 

--- a/src/Dnt.Commands/Packages/SwitchProjectsToPackagesCommand.cs
+++ b/src/Dnt.Commands/Packages/SwitchProjectsToPackagesCommand.cs
@@ -26,7 +26,11 @@ namespace Dnt.Commands.Packages
             }
 
             SwitchToPackages(host, configuration);
-            await RemoveProjectsFromSolutionAsync(configuration, host);
+
+            if (configuration.RemoveProjects)
+            {
+                await RemoveProjectsFromSolutionAsync(configuration, host);
+            }
 
             configuration.Restore = null; // restore information no longer needed
             configuration.Save();
@@ -114,7 +118,8 @@ namespace Dnt.Commands.Packages
             var projectFileName = Path.GetFileName(solutionProject.AbsolutePath);
             var projectDirectory = Path.GetDirectoryName(solutionProject.AbsolutePath);
 
-            if (!mappedProjectFilePaths.Contains(projectFileName)) // do not modify mapped projects
+            // do not modify mapped projects unless we are always keeping them in the solution
+            if (!mappedProjectFilePaths.Contains(projectFileName) || !configuration.RemoveProjects)
             {
                 var restoreProjectInformation = (
                     from r in configuration.Restore

--- a/src/Dnt.Commands/Packages/Switcher/ReferenceSwitcherConfiguration.cs
+++ b/src/Dnt.Commands/Packages/Switcher/ReferenceSwitcherConfiguration.cs
@@ -24,6 +24,9 @@ namespace Dnt.Commands.Packages.Switcher
         [JsonIgnore]
         public string ActualSolution => PathUtilities.ToAbsolutePath(Solution, System.IO.Path.GetDirectoryName(Path));
 
+        [JsonProperty("removeProjects", NullValueHandling = NullValueHandling.Ignore)]
+        public bool RemoveProjects { get; set; } = true;
+
         public string GetActualPath(string path)
         {
             return PathUtilities.ToAbsolutePath(path, System.IO.Path.GetDirectoryName(Path));


### PR DESCRIPTION
Add a configuration option to determine whether projects are removed from the solution when switching between projects and packages.