### PR TITLE
add required indicate for "mappings"

### DIFF
--- a/src/Dnt.Commands/Packages/Switcher/ReferenceSwitcherConfiguration.cs
+++ b/src/Dnt.Commands/Packages/Switcher/ReferenceSwitcherConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using Dnt.Commands.Infrastructure;
 using NConsole;
@@ -17,7 +18,7 @@ namespace Dnt.Commands.Packages.Switcher
         [JsonProperty("solutionFolder")]
         public string SolutionFolder { get; set; }
 
-        [JsonProperty("mappings")]
+        [JsonProperty("mappings", Required = Required.Always)]
         [JsonConverter(typeof(SingleOrArrayConverter))]
         public Dictionary<string, List<string>> Mappings { get; set; }
 
@@ -43,9 +44,16 @@ namespace Dnt.Commands.Packages.Switcher
                 return null;
             }
 
-            var c = JsonConvert.DeserializeObject<ReferenceSwitcherConfiguration>(File.ReadAllText(fileName));
-            c.Path = PathUtilities.ToAbsolutePath(fileName, Directory.GetCurrentDirectory());
-            return c;
+            try
+            {
+                var c = JsonConvert.DeserializeObject<ReferenceSwitcherConfiguration>(File.ReadAllText(fileName));
+                c.Path = PathUtilities.ToAbsolutePath(fileName, Directory.GetCurrentDirectory());
+                return c;
+            }
+            catch (JsonSerializationException e)
+            {
+                throw new ArgumentException(e.Message);
+            }
         }
 
         public void Save()


### PR DESCRIPTION
https://github.com/RicoSuter/DNT/issues/137

I may be wrong, because I didn't use DNT much, but I think it can be done with little blood, if there are no such moments when we need "mappings" to be absent

we also probably need to add Require.Always for the Solution field if it is required for both switch-to-projects/switch-to-packages operations

We may not handle the error, but then it seems to me there will be a bunch of extra lines that are not needed to understand what the error is.
```csharp
catch (JsonSerializationException e)
{
    throw new ArgumentException(e.Message);
}
```