### PR TITLE
Add support for slnx files in switcher

### DIFF
--- a/src/Dnt.Commands/Dnt.Commands.csproj
+++ b/src/Dnt.Commands/Dnt.Commands.csproj
@@ -15,6 +15,7 @@
 	<ItemGroup>
 		<PackageReference Include="Fluid.Core" Version="2.12.0" />
 		<PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="9.0.0" />
+		<PackageReference Include="Microsoft.VisualStudio.SolutionPersistence" Version="1.0.52" />
 		<PackageReference Include="Namotion.Reflection.Cecil" Version="3.2.0" />
 		<PackageReference Include="NConsole" Version="3.12.6605.26941" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/src/Dnt.Commands/Packages/SwitchPackagesToProjectsCommand.cs
+++ b/src/Dnt.Commands/Packages/SwitchPackagesToProjectsCommand.cs
@@ -8,6 +8,8 @@ using Dnt.Commands.Infrastructure;
 using Dnt.Commands.Packages.Switcher;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
+using Microsoft.VisualStudio.SolutionPersistence.Model;
+using Microsoft.VisualStudio.SolutionPersistence.Serializer;
 using NConsole;
 
 namespace Dnt.Commands.Packages
@@ -27,7 +29,7 @@ namespace Dnt.Commands.Packages
             }
 
             await AddProjectsToSolutionAsync(configuration, host);
-            SwitchToProjects(configuration, host);
+            await SwitchToProjects(configuration, host);
 
             configuration.Save();
 
@@ -35,6 +37,138 @@ namespace Dnt.Commands.Packages
         }
 
         private async Task AddProjectsToSolutionAsync(ReferenceSwitcherConfiguration configuration, IConsoleHost host)
+        {
+            var serializer = SolutionSerializers.GetSerializerByMoniker(configuration.ActualSolution);
+            if (serializer is null)
+            {
+                host.WriteError("Solution " + configuration.ActualSolution + " could not be loaded as it's not recognized by the serializer");
+                return;
+            }
+
+            try
+            {
+                var solution = await serializer.OpenAsync(configuration.ActualSolution, CancellationToken.None);
+                var projects = new List<string>();
+                var solutionFolderArg = "";
+                foreach (var mapping in configuration.Mappings)
+                {
+                    foreach (var path in mapping.Value)
+                    {
+                        if (solution.SolutionProjects.All(p =>
+                                p.ActualDisplayName != mapping.Key)) // check that it's not already in the solution
+                        {
+                            projects.Add("\"" + configuration.GetActualPath(path) + "\"");
+                        }
+                    }
+                }
+
+                if (!string.IsNullOrWhiteSpace(configuration.SolutionFolder))
+                    solutionFolderArg = $" --solution-folder {configuration.SolutionFolder}";
+                if (projects.Any())
+                {
+                    await ExecuteCommandAsync(
+                        "dotnet",
+                        "sln \"" + configuration.ActualSolution + "\" add " + string.Join(" ", projects) +
+                        solutionFolderArg,
+                        false, host, CancellationToken.None);
+                }
+            }
+            catch (Exception ex)
+            {
+                host.WriteError("Solution " + configuration.ActualSolution + " could not be loaded. " + ex.Message);
+            }
+        }
+
+        private static async Task SwitchToProjects(ReferenceSwitcherConfiguration configuration, IConsoleHost host)
+        {
+            var serializer = SolutionSerializers.GetSerializerByMoniker(configuration.ActualSolution);
+            if (serializer is null)
+            {
+                host.WriteError("Solution " + configuration.ActualSolution + " could not be loaded as it's not recognized by the serializer");
+                return;
+            }
+
+            try
+            {
+                var solution = await serializer.OpenAsync(configuration.ActualSolution, CancellationToken.None);
+                var globalProperties = ProjectExtensions.GetGlobalProperties(Path.GetFullPath(configuration.ActualSolution));
+
+                ProjectType pt = solution.ProjectTypes.First();
+
+                foreach (var solutionProject in solution.SolutionProjects)
+                {
+                    try
+                    {
+                        using (var projectInformation = ProjectExtensions.LoadProject(solutionProject.FilePath, globalProperties))
+                        {
+                            foreach (var mapping in configuration.Mappings)
+                            {
+                                var packageName = mapping.Key;
+                                var projectPaths = mapping.Value.Select(p => configuration.GetActualPath(p)).ToList();
+
+                                var switchedProjects = SwitchToProject(configuration, solutionProject, projectInformation, packageName, projectPaths, host);
+                                foreach (var s in switchedProjects)
+                                {
+                                    host.WriteMessage("Project " + Path.GetFileName(s.Key) + " packages:\n");
+                                    host.WriteMessage("    " + packageName + " v" + s.Value + "\n    replaced by:\n");
+                                    projectPaths.ForEach(p => host.WriteMessage("    " + Path.GetFileName(p) + "\n"));
+                                }
+                            }
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        host.WriteError($"The project '{solutionProject.FilePath}' could not be loaded: {e}\n");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                host.WriteError("Solution " + configuration.ActualSolution + " could not be loaded. " + ex.Message);
+            }
+        }
+
+        private static IReadOnlyDictionary<string, string> SwitchToProject(ReferenceSwitcherConfiguration configuration,
+            SolutionProjectModel solutionProject, ProjectInformation projectInformation, string packageName, List<string> projectPaths, IConsoleHost host)
+        {
+            var switchedProjects = new Dictionary<string, string>();
+            var project = projectInformation.Project;
+            var projectDirectory = Path.GetFullPath(Path.GetDirectoryName(solutionProject.FilePath));
+
+            var centralVersioning = project.GetProperty("CentralPackagesFile") != null   // https://github.com/microsoft/MSBuildSdks/tree/master/src/CentralPackageVersions
+                || project.GetPropertyValue("ManagePackageVersionsCentrally") == "true"; // https://github.com/NuGet/Home/wiki/Centrally-managing-NuGet-package-versions
+
+            foreach (var item in project.Items
+                .Where(i => i.ItemType == "PackageReference" || i.ItemType == "Reference").ToList())
+            {
+                var packageReference = item.EvaluatedInclude.Split(',').First().Trim();
+
+                if (packageReference == packageName)
+                {
+                    var isPackageReference = (item.ItemType == "PackageReference");
+                    var packageVersion = centralVersioning ? null :
+                        item.Metadata.SingleOrDefault(m => m.Name == "Version")?.EvaluatedValue ?? null;
+
+                    project.RemoveItem(item);
+                    foreach (var projectPath in projectPaths)
+                    {
+                        project.AddItem("ProjectReference",
+                        PathUtilities.ToRelativePath(projectPath, projectDirectory));
+
+                        SetRestoreProjectInformation(configuration, item, project.FullPath, isPackageReference,
+                            packageName, packageVersion);
+                    }
+
+                    switchedProjects[solutionProject.FilePath] = packageVersion;
+                }
+            }
+
+            ProjectExtensions.SaveWithLineEndings(projectInformation);
+
+            return switchedProjects;
+        }
+
+        private async Task AddProjectsToSolutionAsyncLegacy(ReferenceSwitcherConfiguration configuration, IConsoleHost host)
         {
             var solution = SolutionFile.Parse(configuration.ActualSolution);
             var projects = new List<string>();
@@ -55,12 +189,12 @@ namespace Dnt.Commands.Packages
             if (projects.Any())
             {
                 await ExecuteCommandAsync(
-                    "dotnet", "sln \"" + configuration.ActualSolution + "\" add " + string.Join(" ", projects)+ solutionFolderArg, 
+                    "dotnet", "sln \"" + configuration.ActualSolution + "\" add " + string.Join(" ", projects) + solutionFolderArg,
                     false, host, CancellationToken.None);
             }
         }
 
-        private static void SwitchToProjects(ReferenceSwitcherConfiguration configuration, IConsoleHost host)
+        private static void SwitchToProjectsLegacy(ReferenceSwitcherConfiguration configuration, IConsoleHost host)
         {
             var solution = SolutionFile.Parse(configuration.ActualSolution);
             var globalProperties = ProjectExtensions.GetGlobalProperties(Path.GetFullPath(configuration.ActualSolution));
@@ -78,7 +212,7 @@ namespace Dnt.Commands.Packages
                                 var packageName = mapping.Key;
                                 var projectPaths = mapping.Value.Select(p => configuration.GetActualPath(p)).ToList();
 
-                                var switchedProjects = SwitchToProject(configuration, solutionProject, projectInformation, packageName, projectPaths, host);
+                                var switchedProjects = SwitchToProjectLegacy(configuration, solutionProject, projectInformation, packageName, projectPaths, host);
                                 foreach (var s in switchedProjects)
                                 {
                                     host.WriteMessage("Project " + Path.GetFileName(s.Key) + " packages:\n");
@@ -96,7 +230,7 @@ namespace Dnt.Commands.Packages
             }
         }
 
-        private static IReadOnlyDictionary<string, string> SwitchToProject(ReferenceSwitcherConfiguration configuration,
+        private static IReadOnlyDictionary<string, string> SwitchToProjectLegacy(ReferenceSwitcherConfiguration configuration,
             ProjectInSolution solutionProject, ProjectInformation projectInformation, string packageName, List<string> projectPaths, IConsoleHost host)
         {
             var switchedProjects = new Dictionary<string, string>();
@@ -105,7 +239,7 @@ namespace Dnt.Commands.Packages
 
             var centralVersioning = project.GetProperty("CentralPackagesFile") != null   // https://github.com/microsoft/MSBuildSdks/tree/master/src/CentralPackageVersions
                 || project.GetPropertyValue("ManagePackageVersionsCentrally") == "true"; // https://github.com/NuGet/Home/wiki/Centrally-managing-NuGet-package-versions
-            
+
             foreach (var item in project.Items
                 .Where(i => i.ItemType == "PackageReference" || i.ItemType == "Reference").ToList())
             {

--- a/src/Dnt.Commands/Packages/SwitchPackagesToProjectsCommand.cs
+++ b/src/Dnt.Commands/Packages/SwitchPackagesToProjectsCommand.cs
@@ -76,6 +76,7 @@ namespace Dnt.Commands.Packages
             catch (Exception ex)
             {
                 host.WriteError("Solution " + configuration.ActualSolution + " could not be loaded. " + ex.Message);
+                host.WriteError(ex.StackTrace);
             }
         }
 
@@ -92,8 +93,6 @@ namespace Dnt.Commands.Packages
             {
                 var solution = await serializer.OpenAsync(configuration.ActualSolution, CancellationToken.None);
                 var globalProperties = ProjectExtensions.GetGlobalProperties(Path.GetFullPath(configuration.ActualSolution));
-
-                ProjectType pt = solution.ProjectTypes.First();
 
                 foreach (var solutionProject in solution.SolutionProjects)
                 {

--- a/src/Dnt.Commands/Packages/SwitchProjectsToPackagesCommand.cs
+++ b/src/Dnt.Commands/Packages/SwitchProjectsToPackagesCommand.cs
@@ -119,7 +119,7 @@ namespace Dnt.Commands.Packages
                     foreach (var path in mapping.Value)
                     {
                         var project = solution.SolutionProjects.FirstOrDefault
-                        (p => p.FilePath == configuration.GetActualPath(path));
+                        (p => PathUtilities.ToAbsolutePath(p.FilePath, Path.GetDirectoryName(configuration.ActualSolution)) == configuration.GetActualPath(path));
                         if (project != null)
                         {
                             projects.Add("\"" + configuration.GetActualPath(path) + "\"");


### PR DESCRIPTION
Uses new solution persistance nuget package to open and read solution files, supports both legacy sln and new slnx.
Closes #149 